### PR TITLE
CI: install Julia in FormatCheck workflow so runic-action can run

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'


### PR DESCRIPTION
`fredrikekre/runic-action@v1` (v1.4+) requires `julia` in PATH but no longer installs it itself. Add a `julia-actions/setup-julia@v2` step before the action so the format check actually runs (it has been silently passing — i.e. silently failing — across many SciML repos for weeks).

Detected as part of the SciMLBase v3 / OrdinaryDiffEq v7 ecosystem rollout sweep.

Ignore until reviewed by @ChrisRackauckas.