### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Downgrade"
 
 on:
   pull_request:
@@ -19,14 +19,10 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
 
 jobs:
-  tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
+      julia-version: "lts"
+      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,22 +1,19 @@
-name: format-check
+name: "Format Check"
 
 on:
   push:
     branches:
-      - 'master'
-      - 'main'
-      - 'release-'
-    tags: '*'
+      - master
+      - main
+    tags: ["*"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,10 @@
+name: "Spell Check"
+
+on:
+  pull_request:
+
+jobs:
+  spellcheck:
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+# "HSA" appears in Reactome stable identifiers (e.g. R-HSA-70171, HSA = Homo sapiens)
+# and must not be "corrected" to "HAS".
+[default.extend-words]
+HSA = "HSA"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes CI to the SciML standard set using the centralized reusable workflows in `SciML/.github` (each caller pinned `@v1`, `secrets: inherit`).

## Workflows converted
- **CI.yml** (Tests): the old hand-rolled `julia-buildpkg`/`julia-runtest` job is replaced by a `tests.yml@v1` caller. Preserves the original behavior: single Julia version `"1"`, coverage on (the old job ran `julia-processcoverage` + `lcov-reporter`). No group/os matrix existed, so none was added.
- **FormatCheck.yml** (Runic): the old `fredrikekre/runic-action@v1` job is replaced by a `runic.yml@v1` caller. The repo was already Runic-formatted (ran Runic locally, no diff), so no formatting commit was needed.

## Workflows added
- **SpellCheck.yml**: `spellcheck.yml@v1` caller (typos) — standard check, was missing.
- **Downgrade.yml**: `downgrade.yml@v1` caller (`julia-version: lts`, `skip: Pkg,TOML`) — standard check, was missing.

## Dependabot (new)
There was no `.github/dependabot.yml`. Added one with:
- a `github-actions` block (`directory: /`, weekly), and
- a `julia` block (`directory: /`, daily, grouped `all-julia-packages: ["*"]`) to preserve compat automation. Only the root has a `Project.toml` (no `docs/`, no `test/Project.toml`).

## CompatHelper
None present; nothing removed.

## Not changed
- **TagBot.yml** left as-is (custom `JuliaComputing/JuliaSimRegistry` setup with `DOCUMENTER_KEY` / `JULIASIM_REGISTRY_SSH_KEY` and self-hosted runner).
- No `docs/` directory, so no `documentation.yml` caller was added.
- No downstream/IntegrationTest, benchmark, or QA workflow existed; none invented.

## Typos findings
Added a minimal `_typos.toml` ignoring `HSA` — a false positive from Reactome stable identifiers (e.g. `R-HSA-70171`, HSA = *Homo sapiens*), present in `test/pathway.jl` and `test/glycolysis.jl`.

`typos` still reports the following **real** typos (not auto-fixed per policy of not mass-editing prose/identifiers — the SpellCheck check will flag these as red until fixed):
- `README.md`: `appropiate` → `appropriate`
- `src/balance.jl`: `chemcial` → `chemical` (x2, in comments and an error string)
- `src/balance.jl`: `occuring` → `occurring` (x9, mostly the `occuring_elements` identifier and commented-out code)

## Heads-up
Job/check names change (e.g. the test check now reports as `Tests`, the format check as `Runic`). Branch-protection required-status-checks for this repo must be updated to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)