### PR TITLE
Canonicalize test suite to @safetestset for per-unit isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,6 +42,7 @@ JSON3 = "1.9"
 OrdinaryDiffEq = "6, 7"
 PeriodicTable = "1"
 Plots = "1.29"
+SafeTestsets = "0.1, 1"
 StatsBase = "0.33, 0.34"
 Symbolics = "4, 5, 6, 7"
 URIs = "1"
@@ -49,7 +50,8 @@ Unitful = "1.9"
 julia = "1.8"
 [extras]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "Test"]
+test = ["OrdinaryDiffEq", "SafeTestsets", "Test"]

--- a/test/glycolysis.jl
+++ b/test/glycolysis.jl
@@ -1,3 +1,5 @@
+using PubChemReactions, Catalyst, OrdinaryDiffEq
+using Test
 using InvertedIndices
 using Unitful, Plots
 

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -2,6 +2,8 @@ using PubChemReactions, Catalyst, Test
 using OrdinaryDiffEq
 using Graphs
 
+@parameters t
+
 C6H12O6 = PubChemReactions.search_compound("glucose")
 H2O = PubChemReactions.search_compound("water")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,19 @@
 using PubChemReactions, Catalyst, OrdinaryDiffEq
 using Test
-
-@parameters t
+using SafeTestsets
 
 @testset "PubChemReactions.jl" begin
-    @testset "graph" begin
+    @safetestset "graph" begin
         include("graph.jl")
     end
-    @testset "species" begin
+    @safetestset "species" begin
         include("species.jl")
     end
-    # @testset "balance" begin include("balance.jl") end
-    @testset "pathway" begin
+    # @safetestset "balance" begin include("balance.jl") end
+    @safetestset "pathway" begin
         include("pathway.jl")
     end
-    @testset "glycolysis" begin
+    @safetestset "glycolysis" begin
         include("glycolysis.jl")
     end
 end


### PR DESCRIPTION
## What

Canonicalizes the test suite so each independent test unit runs in its own module via `@safetestset` (matching the canonical OrdinaryDiffEq structure). This gives isolation between tests and world-age safety, so a `using` inside one unit can't leak into another.

## Classification

PLAIN-TESTSET repo: `runtests.jl` wrapped each unit in a plain `@testset "X" begin include("x.jl") end` under an outer `@testset "PubChemReactions.jl"`, with shared `using PubChemReactions, Catalyst, OrdinaryDiffEq` / `using Test` and `@parameters t` defined at `runtests.jl` Main top-level and silently leaked into the included files.

## Changes

- **`runtests.jl`**: each inner `@testset "X" begin include("x.jl") end` -> `@safetestset "X" begin include("x.jl") end`. The outer `@testset "PubChemReactions.jl"` summary wrapper is kept (`@safetestset` nests fine inside `@testset`). The commented-out `balance` unit is left commented. Removed the Main-top-level `@parameters t` (it only existed to leak into the included files); `t` is now defined inside each unit that needs it.
- **`graph.jl`**: added `@parameters t` (it previously relied on the leaked Main binding; the other unit files already declared their own `t`).
- **`glycolysis.jl`**: added `using PubChemReactions, Catalyst, OrdinaryDiffEq` and `using Test`. This file previously had no package imports at all and relied entirely on bindings leaked from Main; a `@safetestset` body is a fresh module, so it must be self-contained. `species.jl` and `pathway.jl` were already self-contained.
- **`Project.toml`**: added `SafeTestsets` to `[extras]` + `[targets].test` and `[compat] SafeTestsets = "0.1, 1"`.

The `include("x.jl")` form (rather than an inline `@safetestset` body) is required here and is preserved: every unit uses Catalyst/ModelingToolkit macros (`@species`, `@variables`, `@parameters`, `@named`, `@unpack`), and `include()` evaluates statements sequentially so each file's `using` runs before any package macro is parsed.

## Behavior preservation

Same units run with the same assertions; only the unit wrapping and per-unit imports changed. No test logic, no assertions, and no `@test_broken` lines were altered. There is no GROUP-dispatch ladder or separate QA group in this repo.

## Verification

`CI-will-verify`. Static verification only:
- `Meta.parseall` on `runtests.jl` and all four converted unit files: all parse OK.
- Per-file import audit: every package macro and module-qualified reference in each unit maps to a `using`/`import` now present in that file.

A local runtime run was not attempted because (a) the suite is a heavy, **live-network** integration suite (it hits PubChem/PathBank/Reactome and runs ODE solves), and (b) the package's `Project.toml` does not currently resolve on Julia 1.11 due to a pre-existing `[compat] Downloads = "1.7.0"` entry (the `Downloads` stdlib is `1.6.x` on Julia 1.11), which blocks any local instantiate. That `Downloads` compat issue is pre-existing on `master` and out of scope for this structural PR.

---

Draft. Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)