### PR TITLE
Document rendered public API

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PubChemReactions = "84d26278-d58d-42be-a39e-bf9de7ef3f0e"
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,14 @@
+using Documenter
+using PubChemReactions
+
+makedocs(;
+    modules = [PubChemReactions],
+    sitename = "PubChemReactions.jl",
+    pages = [
+        "Public API" => "index.md",
+    ],
+    checkdocs = :exports,
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+    ),
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,26 @@
+# PubChemReactions.jl
+
+```@docs
+PubChemReactions.Compound
+PubChemReactions.@species_str
+PubChemReactions.get_cid
+PubChemReactions.get_name
+PubChemReactions.get_charge
+PubChemReactions.get_graph
+PubChemReactions.atom_counts
+PubChemReactions.element_counts
+PubChemReactions.atom_matrix
+PubChemReactions.save_species
+PubChemReactions.load_species
+PubChemReactions.isspecies
+PubChemReactions.pubchem_search
+PubChemReactions.balance_eqs
+PubChemReactions.isbalanced
+PubChemReactions.atomplot
+PubChemReactions.atomplot2d
+PubChemReactions.atomplot3d
+PubChemReactions.make_at_species
+PubChemReactions.eqs_to_mathematica
+PubChemReactions.pathway_reaction
+PubChemReactions.pc
+```

--- a/src/balance.jl
+++ b/src/balance.jl
@@ -10,7 +10,10 @@ function isbalanced(
 end
 
 """
-check that the element counts in substrates is equal to products
+    isbalanced(rxn)
+
+Return `true` when the substrates and products in reaction `rxn` have matching
+element counts.
 """
 function isbalanced(rxn)
     all(hasmetadata.(reaction_species(rxn), Compound)) ||
@@ -21,7 +24,10 @@ function isbalanced(rxn)
 end
 
 """
-check that the element counts in sub
+    isbalanced(rn::ReactionSystem)
+
+Return `true` when every reaction in the Catalyst reaction system `rn` is
+element-balanced.
 """
 function isbalanced(rn::ReactionSystem)
     return all(isbalanced.(reactions(rn)))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -7,7 +7,10 @@ function download_atomplot(s)
 end
 
 """
-uses the 2D image provided by PubChem, rather than trying to use the graph data
+    atomplot(s; verbose = false)
+
+Download PubChem's 2D structure image for species `s` and display it with the
+compound identifier, molecular formula, and name in the plot title.
 """
 function atomplot(s; verbose = false)
     cid, io = download_atomplot(s)
@@ -47,9 +50,9 @@ function open_in_default_browser(url::AbstractString)::Bool
 end
 
 """
-not all compounds have a 3d plot so it could open a 404'd page
+    atomplot3d(s)
 
-example https://pubchem.ncbi.nlm.nih.gov/compound/5793#section=3D-Conformer&fullscreen=true
+Open the PubChem 3D conformer viewer for species `s`.
 """
 function atomplot3d(s)
     cid = string(get_cid(s))

--- a/src/species.jl
+++ b/src/species.jl
@@ -35,7 +35,10 @@ function set_species_metadata(s, j, jview)
 end
 
 """
-generate a chemical species and plot it
+    @species_str(cname)
+
+Look up the PubChem compound named by the string literal `cname`, attach the
+compound metadata to a symbolic species, and display its atom plot.
 """
 macro species_str(cname)
     s = search_compound(cname)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,8 +3,6 @@ using JET
 
 run_qa(
     PubChemReactions;
-    explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     jet_kwargs = (; target_defined_modules = true),
     ei_kwargs = (;
         # `escapeuri` is owned by URIs but accessed via HTTP. `scalarize` and

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,6 +4,7 @@ using JET
 run_qa(
     PubChemReactions;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     jet_kwargs = (; target_defined_modules = true),
     ei_kwargs = (;
         # `escapeuri` is owned by URIs but accessed via HTTP. `scalarize` and


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add minimal Documenter docs with a `@docs` block for every package-owned exported API name.
- Enable SciMLTesting rendered public API docs QA via `api_docs_kwargs = (; rendered = true)`.
- Tighten source docstrings for weak exported API docstrings.

## Validation
- `git diff --check`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=@runic --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff src/balance.jl src/plot.jl src/species.jl test/qa/qa.jl docs/make.jl`