### PR TITLE
docs: document public API contracts

### DIFF
--- a/src/balance.jl
+++ b/src/balance.jl
@@ -2,6 +2,42 @@ function atom_count_diff(rxn::Catalyst.Reaction)
     return replace_atom_counts_with_elements(mergewith(-, reverse(atom_counts(rxn))...))
 end
 
+"""
+    isbalanced(substrates, products; substoich = ones(length(substrates)),
+        prodstoich = ones(length(products)))
+
+Determine whether the substrate and product collections contain the same
+stoichiometric atom counts.
+
+# Arguments
+
+- `substrates`: Collection of PubChem species on the left-hand side. Every
+  species must have the atom-bond graph metadata used by `PubChemReactions`.
+- `products`: Collection of PubChem species on the right-hand side.
+
+# Keyword Arguments
+
+- `substoich`: Numeric coefficients for `substrates`. Its length must match
+  `substrates`.
+- `prodstoich`: Numeric coefficients for `products`. Its length must match
+  `products`.
+
+# Returns
+
+`true` when the weighted atom counts match exactly, and `false` otherwise.
+
+# Examples
+
+```julia
+using PubChemReactions
+
+h2 = PubChemReactions.search_compound("hydrogen")
+o2 = PubChemReactions.search_compound("oxygen")
+h2o = PubChemReactions.search_compound("water")
+
+isbalanced([h2, o2], [h2o]; substoich = [2, 1], prodstoich = [2])
+```
+"""
 function isbalanced(
         substrates, products; substoich = ones(length(substrates)),
         prodstoich = ones(length(products))
@@ -12,8 +48,21 @@ end
 """
     isbalanced(rxn)
 
-Return `true` when the substrates and products in reaction `rxn` have matching
-element counts.
+Determine whether the substrate and product species in Catalyst reaction `rxn`
+have matching stoichiometric atom counts.
+
+# Arguments
+
+- `rxn`: A Catalyst `Reaction` whose species have PubChem `Compound` and
+  atom-bond graph metadata.
+
+# Returns
+
+`true` when the reaction is element-balanced, and `false` otherwise. An error
+is thrown when a reaction species lacks the metadata required to count atoms.
+
+The reaction's `substoich` and `prodstoich` fields are passed to the collection
+method, so the check uses the reaction's current stoichiometric coefficients.
 """
 function isbalanced(rxn)
     all(hasmetadata.(reaction_species(rxn), Compound)) ||
@@ -26,8 +75,17 @@ end
 """
     isbalanced(rn::ReactionSystem)
 
-Return `true` when every reaction in the Catalyst reaction system `rn` is
+Determine whether every reaction in Catalyst reaction system `rn` is
 element-balanced.
+
+# Arguments
+
+- `rn`: A Catalyst `ReactionSystem` whose reactions contain PubChem species.
+
+# Returns
+
+`true` when `isbalanced` returns `true` for every reaction in `rn`, and `false`
+otherwise. Metadata errors from an individual reaction are propagated.
 """
 function isbalanced(rn::ReactionSystem)
     return all(isbalanced.(reactions(rn)))
@@ -44,6 +102,19 @@ end
     element_counts(x)
 
 Return atom counts for `x` keyed by `PeriodicTable.Element` values.
+
+For a species or species collection, the result is a dictionary keyed by
+periodic-table elements. For a `Reaction`, the result is a tuple containing
+the substrate and product dictionaries.
+
+# Arguments
+
+- `x`: PubChem species, a collection of species, or a Catalyst `Reaction`.
+
+# Returns
+
+A dictionary, or a substrate/product tuple of dictionaries, containing the
+weighted atom counts keyed by `PeriodicTable.Element`.
 """
 element_counts(x) = replace_atom_counts_with_elements(atom_counts(x))
 element_counts(x::Reaction) = replace_atom_counts_with_elements.(atom_counts(x))
@@ -51,8 +122,18 @@ element_counts(x::Reaction) = replace_atom_counts_with_elements.(atom_counts(x))
 """
     atom_counts(x)
 
-Return atom counts for a PubChem species, reaction, or stoichiometric species
-collection.
+Return atom counts for a PubChem species, reaction, or species collection.
+
+# Arguments
+
+- `x`: A PubChem species, a collection of species, or a Catalyst `Reaction`.
+
+# Returns
+
+For a species or collection, a dictionary keyed by the atomic numbers stored in
+the PubChem atom-bond graph. For a `Reaction`, a tuple containing separate
+substrate and product dictionaries is returned. Reaction dictionaries include
+the reaction's stoichiometric coefficients.
 """
 function atom_counts(s::Num)
     c = getmetadata(s, AtomBondGraph)
@@ -119,12 +200,6 @@ get_elements(s::Vector) = Set(reduce(vcat, get_elements.(s)))
 #     rxn
 # end
 
-"""
-    balance_eqs(substrates, products; add_constraint_eq = true)
-    balance_eqs(rxn::Reaction; add_constraint_eq = true)
-
-Construct symbolic element and charge balance equations for a reaction.
-"""
 function balance_eqs(
         x, occurring_elements, atomcounts, chgs, n_specs, n_subs; add_constraint_eq = false
     )
@@ -174,6 +249,41 @@ function balance_setup(substrates, products)
     return occurring_elements, atomcounts, chgs, n_specs, n_subs
 end
 
+"""
+    balance_eqs(substrates, products; add_constraint_eq = true)
+
+Construct symbolic element and charge balance equations for collections of
+PubChem substrate and product species.
+
+# Arguments
+
+- `substrates`: Collection of PubChem species on the left-hand side.
+- `products`: Collection of PubChem species on the right-hand side.
+
+# Keyword Arguments
+
+- `add_constraint_eq`: If `true`, append an equation fixing the coefficient of
+  the final species to `1`. This removes the scale ambiguity from the returned
+  homogeneous balance equations. The default is `true`.
+
+# Returns
+
+A `Vector{Symbolics.Equation}` containing one symbolic coefficient for each
+species in `vcat(substrates, products)`, with equations for every occurring
+element and, when needed, total charge. The substrate coefficients appear on
+the left-hand side and product coefficients on the right-hand side.
+
+# Examples
+
+```julia
+using PubChemReactions
+
+h2 = PubChemReactions.search_compound("hydrogen")
+o2 = PubChemReactions.search_compound("oxygen")
+h2o = PubChemReactions.search_compound("water")
+eqs = balance_eqs([h2, o2], [h2o])
+```
+"""
 function balance_eqs(substrates, products; add_constraint_eq = true)
     occurring_elements, atomcounts, chgs, n_specs,
         n_subs = balance_setup(substrates, products)
@@ -181,6 +291,28 @@ function balance_eqs(substrates, products; add_constraint_eq = true)
     return balance_eqs(x, occurring_elements, atomcounts, chgs, n_specs, n_subs; add_constraint_eq)
 end
 
+"""
+    balance_eqs(rxn::Reaction; add_constraint_eq = true)
+
+Construct symbolic element and charge balance equations for the substrate and
+product species in Catalyst reaction `rxn`.
+
+# Arguments
+
+- `rxn`: A Catalyst `Reaction` containing PubChem species. Its current
+  stoichiometric coefficients are not used; the returned equations introduce a
+  new coefficient for each species.
+
+# Keyword Arguments
+
+- `add_constraint_eq`: If `true`, append an equation fixing the coefficient of
+  the final species to `1`. The default is `true`.
+
+# Returns
+
+A `Vector{Symbolics.Equation}` equivalent to
+`balance_eqs(rxn.substrates, rxn.products; add_constraint_eq)`.
+"""
 function balance_eqs(rxn::Reaction; add_constraint_eq = true)
     return balance_eqs(rxn.substrates, rxn.products; add_constraint_eq)
 end
@@ -190,6 +322,17 @@ eq_to_term(eq) = eq.lhs - eq.rhs
     atom_matrix(rxn::Reaction)
 
 Return the linear coefficient matrix for the balance equations of `rxn`.
+
+# Arguments
+
+- `rxn`: A Catalyst `Reaction` containing PubChem species.
+
+# Returns
+
+A matrix whose columns correspond to the species in the reaction and whose
+rows contain the coefficients of the element and charge balance equations. The
+matrix is formed from `balance_eqs(rxn)` and therefore includes the
+normalization equation by default.
 """
 function atom_matrix(rxn::Reaction)
     eqs = balance_eqs(rxn)

--- a/src/data.jl
+++ b/src/data.jl
@@ -99,6 +99,18 @@ end
     get_graph(s)
 
 Return the atom-bond graph metadata attached to PubChem species `s`.
+
+# Arguments
+
+- `s`: A symbolic species with `AtomBondGraph` metadata.
+
+# Returns
+
+The `AtomBondGraph` metadata value associated with `s`.
+
+# Errors
+
+Throws an error when `s` is not recognized as a PubChem species.
 """
 get_graph(s) = isspecies(s) ? getmetadata(s, AtomBondGraph) : error("no graph for var $s")
 
@@ -106,6 +118,18 @@ get_graph(s) = isspecies(s) ? getmetadata(s, AtomBondGraph) : error("no graph fo
     get_charge(s)
 
 Return the formal charge stored in the PubChem species metadata for `s`.
+
+# Arguments
+
+- `s`: A symbolic PubChem species with compound-charge metadata.
+
+# Returns
+
+The integer formal charge associated with `s`.
+
+# Errors
+
+Throws an error when `s` is not recognized as a PubChem species.
 """
 function get_charge(s)
     return isspecies(s) ? getmetadata(s, CompoundCharge).charge : error("no charge for var $s")
@@ -121,6 +145,14 @@ end
     get_cid(s)
 
 Return the PubChem compound identifier attached to species `s`.
+
+# Arguments
+
+- `s`: A symbolic PubChem species with `Compound` metadata.
+
+# Returns
+
+The integer PubChem compound identifier stored in `s`.
 """
 function get_cid(s)
     return getmetadata(s, Compound).cid
@@ -138,6 +170,14 @@ end
     get_name(s)
 
 Return the PubChem compound name attached to species `s`.
+
+# Arguments
+
+- `s`: A symbolic PubChem species with `Compound` metadata.
+
+# Returns
+
+The compound name stored in the `Compound` metadata for `s`.
 """
 function get_name(s)
     return getmetadata(s, Compound).name
@@ -221,5 +261,15 @@ end
     pubchem_search(s)
 
 Open a PubChem search for query `s` in the system default browser.
+
+# Arguments
+
+- `s`: A string or other value that can be interpolated into a PubChem search
+  query.
+
+# Returns
+
+`true` when the platform-specific browser command is started successfully, and
+`false` when the platform is unsupported or the command fails.
 """
 pubchem_search(s) = open_in_default_browser(joinpath(PC_ROOT, "#query=$s"))

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -1,10 +1,39 @@
 """
-    Compound
+    Compound(name, cid, json, json_view)
 
 Metadata container for a PubChem compound record attached to a symbolic species.
 
 Stores the compound name, PubChem compound identifier, PUG record JSON, and
 PUG-View JSON for later property queries and graph construction.
+
+# Fields
+
+- `name::String`: Compound name from the PubChem PUG-View record.
+- `cid::Int`: PubChem compound identifier.
+- `json::JSON3.Object`: The compound record returned by the PubChem PUG API.
+- `json_view::JSON3.Object`: The detailed record returned by the PubChem PUG-View API.
+
+# Constructor
+
+`Compound(name, cid, json, json_view)` constructs the metadata container from
+the name, identifier, and the two PubChem JSON objects. The constructor stores
+these values without modifying the JSON objects.
+
+# Returns
+
+A `Compound` value suitable for attaching to a symbolic species with
+`SymbolicUtils.setmetadata`.
+
+# Examples
+
+```julia
+using JSON3
+using PubChemReactions
+
+record = JSON3.read("{}")
+compound = Compound("Water", 962, record, record)
+compound.cid
+```
 """
 struct Compound
     name::String

--- a/src/pathway.jl
+++ b/src/pathway.jl
@@ -43,6 +43,17 @@ end
     pathway_reaction(rxn_str)
 
 Parse a PubChem pathway reaction string into a Catalyst `Reaction` with unit rate.
+
+# Arguments
+
+- `rxn_str`: A PubChem pathway reaction string containing HTML links to the
+  reactant and product compounds.
+
+# Returns
+
+A Catalyst `Reaction` with rate `1`, with reactants and products represented as
+PubChem species. Compound records are retrieved while parsing the linked
+species.
 """
 pathway_reaction(rxn_str) = Reaction(1, parse_pathway_reaction(rxn_str)...)
 

--- a/src/species.jl
+++ b/src/species.jl
@@ -50,6 +50,15 @@ end
     isspecies(s)
 
 Return `true` when `s` has PubChem atom-bond graph metadata.
+
+# Arguments
+
+- `s`: A symbolic expression or other value to inspect.
+
+# Returns
+
+`true` when `s` has `AtomBondGraph` metadata and `false` otherwise. This
+predicate does not perform a network request or validate any other metadata.
 """
 function isspecies(s)
     return hasmetadata(s, AtomBondGraph)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,6 +2,20 @@
     make_at_species(sps; current_name = true)
 
 Return a Catalyst `@species` expression string for PubChem species `sps`.
+
+# Arguments
+
+- `sps`: A PubChem symbolic species with compound name and CID metadata.
+
+# Keyword Arguments
+
+- `current_name`: If `true`, use the current symbolic operation name. If
+  `false`, use the PubChem compound name. The default is `true`.
+
+# Returns
+
+A string containing a Catalyst `@species` expression with the species CID and
+`save`/`load` options enabled.
 """
 function make_at_species(sps; current_name = true)
     name = current_name ? nameof(operation(Symbolics.value(sps))) :
@@ -19,6 +33,15 @@ end
     eqs_to_mathematica(eqs)
 
 Convert symbolic equations to a Wolfram Language list string.
+
+# Arguments
+
+- `eqs`: An iterable collection of symbolic equations.
+
+# Returns
+
+A string containing the equations in a Wolfram Language list, with Julia's
+`~`, `&`, and `|` operators converted to `==`, `&&`, and `||`.
 """
 function eqs_to_mathematica(eqs)
     es = string.(eqs)


### PR DESCRIPTION
## Summary

- Move the balance_eqs documentation from the internal six-argument helper onto the public two-argument and Reaction definitions.
- Document the collection isbalanced interface and expand the existing Reaction/ReactionSystem contracts.
- Expand Compound with SciMLStyle fields, constructor, return details, and an executable constructor example.
- Add argument/return/error contracts to the other clearly public API docstrings, including plotting and browser helpers.
- Remove the deprecated repository-specific JET target_defined_modules override; SciMLTesting's standard target_modules default now handles package scoping.
- Keep the existing docs/src/index.md API list; it already renders every changed public name. No runtime behavior or test code was changed.

## Verification

- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: QA/qa.jl 21/21; package tests passed.
- `julia --project=.docs-env docs/make.jl`: Documenter doctest, cross-reference, checkdocs=:exports, and HTML rendering passed.
- `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` passed on the preceding docs commit: glycolysis 5/5, graph 3/3, pathway completed, species 10/10.
- Runic formatting check passed for all changed Julia files.
- typos --diff and git diff --check passed.
- The Compound example ran successfully and produced JSON3.Object with cid=962.
- The checks above were run on Julia 1.12; separate Julia 1.10 and 1.11 jobs were not run locally.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
