### PR TITLE
fix: retry transient PubChem HTTP failures in tests

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -1,3 +1,12 @@
+"""
+    pubchem_get(url; kwargs...)
+
+Perform a GET request with retries enabled for transient PubChem/Rhea network failures.
+"""
+function pubchem_get(url; kwargs...)
+    return HTTP.get(url; retry = true, retries = 3, readtimeout = 120, kwargs...)
+end
+
 pug_url_name(cname) = joinpath(PUG_URL, "compound/name/$(cname)/record/JSON")
 pug_view_url_name(cname) = joinpath(PUG_VIEW_URL, "compound/name/$(cname)/JSON")
 
@@ -9,7 +18,7 @@ function get_cids_from_cname(cname::AbstractString; verbose = false)
     cname = HTTP.escapeuri(cname)
     input_url = "$(PUG_URL)/compound/name/$(cname)/cids/JSON"
     verbose && @info input_url
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     if res.status == 200
         return JSON3.read(String(res.body))::JSON3.Object
     else
@@ -27,7 +36,7 @@ function get_json_from_cname(cname::AbstractString; verbose = false)
     cname = HTTP.escapeuri(cname)
     input_url = "$(PUG_URL)/compound/name/$(cname)/record/JSON/" #?record_type=3d"
     verbose && @info input_url
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     if res.status == 200
         return JSON3.read(String(res.body))
     else
@@ -59,12 +68,12 @@ end
 
 function get_json_and_view(input_url; verbose = false)
     verbose && @info input_url
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     if res.status == 200
         j = JSON3.read(String(res.body))::JSON3.Object
         cid = (j.PC_Compounds::JSON3.Array)[1].id.id.cid
         input_url2 = "$(PUG_VIEW_URL)/data/compound/$(cid)/JSON"
-        j2 = JSON3.read(String(HTTP.get(input_url2).body))::JSON3.Object
+        j2 = JSON3.read(String(pubchem_get(input_url2).body))::JSON3.Object
         return j, j2
     else
         error("Cannot Find record at $input_url.")
@@ -74,7 +83,7 @@ end
 function get_json_from_cid(cid; verbose = false)
     input_url = "$(PUG_URL)/compound/cid/$(cid)/record/JSON"
     verbose && @info input_url
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     if res.status == 200
         return JSON3.read(String(res.body))
     else
@@ -232,7 +241,7 @@ end
 function get_chebi_id(csym)
     cid = get_cid(csym)
     input_url = "$PUG_VIEW_URL/data/compound/$cid/JSON/?heading=Biochemical+Reactions"
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     j = JSON3.read(String(res.body))::JSON3.Object
     record = j[:Record]::JSON3.Object
     reference = record[:Reference]::JSON3.Array

--- a/src/data.jl
+++ b/src/data.jl
@@ -4,7 +4,7 @@
 Perform a GET request with retries enabled for transient PubChem/Rhea network failures.
 """
 function pubchem_get(url; kwargs...)
-    return HTTP.get(url; retry = true, retries = 3, readtimeout = 120, kwargs...)
+    return HTTP.get(url; retry = true, retries = 3, kwargs...)
 end
 
 pug_url_name(cname) = joinpath(PUG_URL, "compound/name/$(cname)/record/JSON")

--- a/src/rhea.jl
+++ b/src/rhea.jl
@@ -37,7 +37,7 @@ function get_biochem_rxns(csym, csyms...)
     end
 
     input_url = "$RHEA_URL/?query=$(chebi_ids)&columns=rhea-id,equation,chebi-id&format=tsv"
-    res = HTTP.get(input_url)
+    res = pubchem_get(input_url)
     if res.status == 200
         return CSV.read(IOBuffer(res.body), DataFrame)
     else

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -8,14 +8,7 @@ using PubChemReactions: @species
 
 @variables t
 
-C6H12O6 = PubChemReactions.search_compound("glucose")
-H2O = PubChemReactions.search_compound("water")
-
-df = PubChemReactions.get_biochem_rxns(C6H12O6, H2O)
-eqs = df[!, :Equation]
-eq = first(eqs) # I happen to know this one has no prefixed stoich data
-
-h2o = PubChemReactions.search_compound("water")
+@species h2o(t) [cid = 962, save = true, load = true]
 @test PubChemReactions.isspecies(h2o)
 @test PubChemReactions.get_graph(h2o) isa PubChemReactions.AtomBondGraph
 


### PR DESCRIPTION
## Summary
- Add `pubchem_get` wrapper with HTTP retries for all PubChem/Rhea GET requests in `data.jl` and `rhea.jl`
- Remove unused top-level `search_compound` / `get_biochem_rxns` setup from `test/graph.jl` that caused flaky TLS failures in CI without contributing to any assertions
- Use explicit PubChem CIDs in `graph.jl`, matching the pattern in `species.jl`

## Root cause
CI failed in `Core/graph.jl` with `HTTP/2 read loop failed` / TLS connection reset when calling `search_compound("glucose")` after glycolysis tests had already made many PubChem requests. The removed setup code was not tested and duplicated network calls.

## Test plan
- [x] Ran `test/graph.jl` in isolation locally — all 3 assertions pass
- [ ] CI Core group on fork branch